### PR TITLE
fix for font awesome in grunt build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -373,9 +373,9 @@ module.exports = function (grunt) {
           src: ['generated/*']
         }, {
           expand: true,
-          cwd: '.',
-          src: 'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*',
-          dest: '<%= yeoman.dist %>'
+          cwd: 'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/',
+          src: '*',
+          dest: '<%= yeoman.dist %>/fonts'
         }]
       },
       styles: {


### PR DESCRIPTION
This should fix the issue with missing Font Awesome fonts in our build. Tested locally.

Definitely want a second pair of eyes on this, @jsheedy could you approve?
